### PR TITLE
Support workflows, search for named build

### DIFF
--- a/cart.go
+++ b/cart.go
@@ -17,13 +17,22 @@ import (
 )
 
 const (
-	buildListURL = "https://circleci.com/api/v1/project/%s/tree/%s?limit=1&filter=successful&circle-token=%s"
+	// The limit in this URL needs to be at least as long as the number of builds in a workflow
+	buildListURL = "https://circleci.com/api/v1/project/%s/tree/%s?limit=%d&filter=successful&circle-token=%s"
 	artifactsURL = "https://circleci.com/api/v1/project/%s/%d/artifacts?circle-token=%s"
 )
 
+type workflow struct {
+	JobName      string `json:"job_name"`
+	JobId        string `json:"job_id"`
+	WorkflowName string `json:"workflow_name"`
+	WorkflowId   string `json:"workflow_id"`
+}
+
 type build struct {
-	BuildNum int    `json:"build_num"`
-	Revision string `json:"vcs_revision"`
+	BuildNum  int       `json:"build_num"`
+	Revision  string    `json:"vcs_revision"`
+	Workflows *workflow `json:"workflows"` // plural name but singleton struct
 }
 
 type artifact struct {
@@ -31,12 +40,14 @@ type artifact struct {
 }
 
 var (
-	project         string
-	branch          string
-	buildNum        int
-	circleToken     string
-	outputPath      string
-	verbose, dryRun bool
+	project               string
+	branch                string
+	buildNum              int
+	circleToken           string
+	outputPath            string
+	workflowArtifactBuild string
+	workflowDepth         int
+	verbose, dryRun       bool
 )
 
 func main() {
@@ -46,6 +57,9 @@ func main() {
 	flag.StringVar(&project, "repo", "", "github `username/repo`")
 	flag.StringVar(&branch, "branch", "master", "search builds for branch `name`")
 	flag.IntVar(&buildNum, "build", 0, "get artifact for build number, ignoring branch")
+	flag.StringVar(&workflowArtifactBuild, "workflow-artifact-build", "",
+		"if branch build was workflow, look for this name build to find the artifacts")
+	flag.IntVar(&workflowDepth, "workflow-depth", 2, "how far back to look for workflows")
 	flag.StringVar(&circleToken, "token", "", "CircleCI auth token")
 	flag.StringVar(&outputPath, "o", "", "output file `path`")
 	flag.BoolVar(&verbose, "v", false, "verbose output")
@@ -81,38 +95,14 @@ func main() {
 	case circleToken == "":
 		flag.Usage()
 		log.Fatal("no auth token set: use $CIRCLE_TOKEN or flag -token")
+	case workflowDepth < 1:
+		flag.Usage()
+		log.Fatal("workflow depth must be a positive (smallish) integer")
 	case buildNum > 0:
 		// Don't look for a green build.
 		fmt.Printf("Build: %d\n", buildNum)
 	default:
-		u := fmt.Sprintf(buildListURL, project, branch, circleToken)
-		if verbose {
-			fmt.Println("Build list:", u)
-		}
-		req, err := http.NewRequest("GET", u, nil)
-		if err != nil {
-			log.Fatal(err)
-		}
-		req.Header.Set("Accept", "application/json")
-		res, err := http.DefaultClient.Do(req)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer res.Body.Close()
-		body := new(bytes.Buffer)
-		if _, err := io.Copy(body, res.Body); err != nil {
-			log.Fatal(err)
-		}
-		var builds []build
-		if err := json.Unmarshal(body.Bytes(), &builds); err != nil {
-			log.Fatalf("%s: %s", err, body.String())
-		}
-		if len(builds) == 0 {
-			log.Fatalf("no builds found for branch: %s", branch)
-		}
-		build := builds[0]
-		buildNum = build.BuildNum
-		fmt.Printf("build: %d branch: %s rev: %s\n", buildNum, branch, build.Revision[:8])
+		buildNum = circleFindBuild(project, branch, circleToken)
 	}
 
 	// Get artifact from buildNum
@@ -142,6 +132,66 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("Wrote %s (%d bytes) to %s\n", artifactName, n, outputPath)
+}
+
+func circleFindBuild(project, branch, circleToken string) (buildNum int) {
+	u := fmt.Sprintf(buildListURL, project, branch, workflowDepth, circleToken)
+	if verbose {
+		fmt.Println("Build list:", u)
+	}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer res.Body.Close()
+	body := new(bytes.Buffer)
+	if _, err := io.Copy(body, res.Body); err != nil {
+		log.Fatal(err)
+	}
+	var (
+		builds []build
+		build  build
+	)
+	if err := json.Unmarshal(body.Bytes(), &builds); err != nil {
+		log.Fatalf("%s: %s", err, body.String())
+	}
+	if len(builds) == 0 {
+		log.Fatalf("no builds found for branch: %s", branch)
+	}
+	if workflowArtifactBuild != "" && builds[0].Workflows != nil && builds[0].Workflows.JobName != workflowArtifactBuild {
+		fmt.Printf("build: branch %q build %d is %q part of workflow %q, searching for build %q\n",
+			branch, builds[0].BuildNum, builds[0].Workflows.JobName,
+			builds[0].Workflows.WorkflowName, workflowArtifactBuild)
+		if len(builds) < 2 {
+			log.Fatalf("build: failed to find a build %q in workflow %q branch %q",
+				workflowArtifactBuild, builds[0].Workflows.WorkflowName, branch)
+		}
+		for i := 1; i < len(builds); i++ {
+			if builds[i].Workflows != nil &&
+				builds[i].Workflows.WorkflowId == builds[0].Workflows.WorkflowId &&
+				builds[i].Workflows.JobName == workflowArtifactBuild {
+				fmt.Printf("build: workflow %q branch %q found build %q at offset %d\n",
+					builds[0].Workflows.WorkflowName, branch, workflowArtifactBuild, i)
+				build = builds[i]
+				buildNum = build.BuildNum
+				break
+			}
+		}
+		if buildNum == 0 {
+			log.Fatalf("build: failed to find a suitable build for workflow %q (%q)",
+				builds[0].Workflows.WorkflowName, builds[0].Workflows.WorkflowId)
+		}
+	} else {
+		build = builds[0]
+		buildNum = build.BuildNum
+	}
+	fmt.Printf("build: %d branch: %s rev: %s\n", buildNum, branch, build.Revision[:8])
+	return
 }
 
 func downloadArtifact(artifacts []artifact, name, outputPath string) (int64, error) {

--- a/cart.go
+++ b/cart.go
@@ -57,9 +57,8 @@ func main() {
 	flag.StringVar(&project, "repo", "", "github `username/repo`")
 	flag.StringVar(&branch, "branch", "master", "search builds for branch `name`")
 	flag.IntVar(&buildNum, "build", 0, "get artifact for build number, ignoring branch")
-	flag.StringVar(&workflowArtifactBuild, "workflow-artifact-build", "",
-		"if branch build was workflow, look for this name build to find the artifacts")
-	flag.IntVar(&workflowDepth, "workflow-depth", 2, "how far back to look for workflows")
+	flag.StringVar(&workflowArtifactBuild, "workflow-artifact-build", "", "if using a workflow, look for artifacts under build: `name`")
+	flag.IntVar(&workflowDepth, "workflow-depth", 2, "how many workflow builds to check")
 	flag.StringVar(&circleToken, "token", "", "CircleCI auth token")
 	flag.StringVar(&outputPath, "o", "", "output file `path`")
 	flag.BoolVar(&verbose, "v", false, "verbose output")


### PR DESCRIPTION
When a Circle CI "workflow" is used, the artifacts might not have been
generated by the latest build on the branch.  Permit the caller to use
`-workflow-artifact-build build` (and perhaps also `-workflow-depth 3`
or the like) to search for a particular named build job within the
workflow.

@case @cee-dub 